### PR TITLE
feat(pipeline): add run_once_min + integration test

### DIFF
--- a/tests/test_pipeline_runner_min_integration.py
+++ b/tests/test_pipeline_runner_min_integration.py
@@ -1,0 +1,17 @@
+import os
+import pytest
+from pathlib import Path
+
+from pipeline.runner import run_once_min
+
+
+@pytest.mark.integration
+def test_pipeline_run_once_min_skips_without_key(tmp_path):
+	if not os.getenv("POLYGON_API_KEY"):
+		pytest.skip("POLYGON_API_KEY not set; skipping minimal pipeline test.")
+
+	log_file = tmp_path / "min_log.csv"
+	run_once_min(["AAPL"], days=5, log_path=str(log_file))
+	assert log_file.exists()
+	contents = log_file.read_text(encoding="utf-8")
+	assert "AAPL" in contents


### PR DESCRIPTION
Add minimal pipeline run_once_min using PolygonClient.get_last_n_days with CSV logging. Include integration test that skips when POLYGON_API_KEY is absent. Zero-contamination policy observed (real Polygon only).