### PR TITLE
chore(pipeline): ISO-8601 timestamps in run_once_min

### DIFF
--- a/pipeline/runner.py
+++ b/pipeline/runner.py
@@ -54,8 +54,19 @@ def run_once_min(symbols: List[str], days: int = 7, log_path: str = "pipeline_mi
                 first_close = float(results[0].get("c", 0.0))
                 last_close = float(results[-1].get("c", 0.0))
                 pct = ((last_close - first_close) / first_close) if first_close > 0 else 0.0
-                start_iso = results[0].get("t")
-                end_iso = results[-1].get("t")
+                # Convert Polygon epoch-ms timestamps to ISO-8601 UTC
+                try:
+                    t_start = results[0].get("t")
+                    ts_ms_start = int(t_start) if t_start is not None else None
+                    start_iso = datetime.fromtimestamp(ts_ms_start / 1000.0, tz=UTC).isoformat() if ts_ms_start is not None else ""
+                except Exception:
+                    start_iso = ""
+                try:
+                    t_end = results[-1].get("t")
+                    ts_ms_end = int(t_end) if t_end is not None else None
+                    end_iso = datetime.fromtimestamp(ts_ms_end / 1000.0, tz=UTC).isoformat() if ts_ms_end is not None else ""
+                except Exception:
+                    end_iso = ""
             else:
                 first_close = 0.0
                 last_close = 0.0

--- a/tests/test_pipeline_runner_min_integration.py
+++ b/tests/test_pipeline_runner_min_integration.py
@@ -1,0 +1,17 @@
+import os
+import pytest
+from pathlib import Path
+
+from pipeline.runner import run_once_min
+
+
+@pytest.mark.integration
+def test_pipeline_run_once_min_skips_without_key(tmp_path):
+	if not os.getenv("POLYGON_API_KEY"):
+		pytest.skip("POLYGON_API_KEY not set; skipping minimal pipeline test.")
+
+	log_file = tmp_path / "min_log.csv"
+	run_once_min(["AAPL"], days=5, log_path=str(log_file))
+	assert log_file.exists()
+	contents = log_file.read_text(encoding="utf-8")
+	assert "AAPL" in contents


### PR DESCRIPTION
Convert Polygon epoch-ms to ISO-8601 UTC for start/end timestamps in minimal pipeline log. Zero-contamination preserved (real data only).